### PR TITLE
ci: bump Mic92/hestia to v1.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
 
       - name: Setup Nix cache (hestia)
-        uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+        uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
 
       - name: build
         run: nix build -L .#checks.x86_64-linux.build
@@ -43,7 +43,7 @@ jobs:
         uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
 
       - name: Setup Nix cache (hestia)
-        uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+        uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
 
       - name: formatting
         run: nix build -L .#checks.x86_64-linux.formatting

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: Run garbage collection
         run: '"${HESTIA_BIN}" gc ${{ inputs.dry-run && ''--dry-run'' || '''' }}'
         env:


### PR DESCRIPTION
Hestia [v1.0.2](https://github.com/Mic92/hestia/releases/tag/v1.0.2) is the first stable release line. It also moved `action.yml` to the repo root, so the path shortens from `Mic92/hestia/action@<sha>` to `Mic92/hestia@<sha>`. Pin stays a SHA with a `# v1.0.2` marker for Dependabot.